### PR TITLE
do not use `Buffer` in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,14 +280,14 @@ it is old.
 ### Txt Helper
 
 The default `TXT` response of dns-queries is a list of `Uint8Array`'s. If you have a
-`TXT` response you can use the `combineTXT` API to combine the requests.
+`TXT` response you can use the `combineTxt` API to combine the requests.
 
 ```js
-import { combineTXT } from 'dns-query'
+import { combineTxt } from 'dns-query'
 
 const response = await query(/* ... */)
 if (response.question.type === 'TXT') {
-  const txt = response.answers.map(answer => combineTXT(answer.data))
+  const txt = response.answers.map(answer => combineTxt(answer.data))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ try {
     endpoints: ['dns.google', 'dns.switch.ch'], // See more about endpoints below!
 
     /* (optional) */
-    retry: 3, // retries if a given endpoint fails; -1 = infinite retries; 0 = no retry
+    retries: 3, // retries if a given endpoint fails; -1 = infinite retries; 0 = no retry
     timeout: 4000, // (default=30000) timeout for single requests
     signal, // An AbortSignal to abort the request
   })

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ let options
 options = 'doh' // Filter to use only doh endpoints
 options = 'dns' // Filter to use only dns servers (Node.js only!)
 options = ['@cloudflare', '@google', '@opendns'] // Use specific named endpoints
-options = ['https://cloudflare-dns.com/dns-query']) // For a convenient API, you can also define regular endpoints...
+options = ['https://cloudflare-dns.com/dns-query'] // For a convenient API, you can also define regular endpoints...
 options = [{ host: 'cloudflare-dns.com' }] // ... and bypass the well-known entries.
 options = (endpoint) => endpoint.protocol === 'https:' // Use a filter against the well-known endpoints
 options = Promise.resolve('doh') // The endpoints can also be a promise

--- a/index.mjs
+++ b/index.mjs
@@ -175,7 +175,7 @@ function concatUint8 (arrs) {
   return res
 }
 
-export function combineTXT (inputs) {
+export function combineTxt (inputs) {
   return decode(concatUint8(inputs))
 }
 
@@ -321,7 +321,7 @@ export function lookupTxt (domain, opts) {
           .filter(answer => answer.type === 'TXT' && answer.data)
           .map(answer => {
             return ({
-              data: combineTXT(answer.data),
+              data: combineTxt(answer.data),
               ttl: answer.ttl
             })
           })

--- a/lib.d.ts
+++ b/lib.d.ts
@@ -7,7 +7,7 @@ export function request (url: URL, method: 'POST' | 'GET', packet: Uint8Array, t
   error: Error
   response: Response
 } | {
-  data: Buffer
+  data: Uint8Array
   response: Response
 }>
 export function loadJSON (url: URL, cache: null | {


### PR DESCRIPTION
Remove the usage of `Buffer` in code executed by both NodeJS and browser.

This removes the need for polyfilling the `Browser` NodeJS built-in in the browser.