### PR TITLE
fix: Naming discrepancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,14 +280,14 @@ it is old.
 ### Txt Helper
 
 The default `TXT` response of dns-queries is a list of `Uint8Array`'s. If you have a
-`TXT` response you can use the `combineTXT` API to combine the requests.
+`TXT` response you can use the `combineTxt` API to combine the requests.
 
 ```js
-import { combineTXT } from 'dns-query'
+import { combineTxt } from 'dns-query'
 
 const response = await query(/* ... */)
 if (response.question.type === 'TXT') {
-  const txt = response.answers.map(answer => combineTXT(answer.data))
+  const txt = response.answers.map(answer => combineTxt(answer.data))
 }
 ```
 

--- a/index.mjs
+++ b/index.mjs
@@ -175,7 +175,7 @@ function concatUint8 (arrs) {
   return res
 }
 
-export function combineTXT (inputs) {
+export function combineTxt (inputs) {
   return decode(concatUint8(inputs))
 }
 
@@ -321,7 +321,7 @@ export function lookupTxt (domain, opts) {
           .filter(answer => answer.type === 'TXT' && answer.data)
           .map(answer => {
             return ({
-              data: combineTXT(answer.data),
+              data: combineTxt(answer.data),
               ttl: answer.ttl
             })
           })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -65,7 +65,7 @@ export interface WellknownOpts {
 }
 
 export function validateResponse <R>(res: R): R;
-export function combineTXT(inputs: Uint8Array[]): Uint8Array;
+export function combineTxt(inputs: Uint8Array[]): Uint8Array;
 
 export interface WellknownData {
   resolvers: Resolver[];


### PR DESCRIPTION
As mentioned by @D4nte, the `combineTXT` method is different from `lookupTxt` and it would good to have that same. As this would be a breaking change, I am opening this PR here. @D4nte Do you think this is important enough to warrant the breaking change?